### PR TITLE
Fix the scrubInput method to remove all HTML tags

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -66,7 +66,22 @@ $("#myBtn").click(function() {
 });
 
 function scrubInput(str) {
-  return str.replace("[(;)]", "");
+  var tagBody = '(?:[^"\'>]|"[^"]*"|\'[^\']*\')*';
+
+  var tagOrComment = new RegExp(
+      '<(?:'
+      // Comment body.
+      + '!--(?:(?:-*[^->])*--+|-?)'
+      // Special "raw text" elements whose content should be elided.
+      + '|script\\b' + tagBody + '>[\\s\\S]*?</script\\s*'
+      + '|style\\b' + tagBody + '>[\\s\\S]*?</style\\s*'
+      // Regular name
+      + '|/?[a-z]'
+      + tagBody
+      + ')>',
+      'gi');
+
+  return str.replace(tagOrComment, "");
 }
 function gotData(data) {
   var dataset = data.val();


### PR DESCRIPTION
The code to scrub the input wasn't actually doing a regex, but instead simply checking against a string. 

This new fix will remove all html tags from the provided string input.